### PR TITLE
Named integer outputs

### DIFF
--- a/ClipperComponents/BooleanComponent.cs
+++ b/ClipperComponents/BooleanComponent.cs
@@ -5,6 +5,7 @@ using System.Windows.Forms;
 using ClipperLib;
 using GH_IO.Serialization;
 using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
 using Rhino;
 using Rhino.Geometry;
 using StudioAvw.Clipper.Components.Helpers;
@@ -17,6 +18,7 @@ namespace StudioAvw.Clipper.Components
     /// </summary>
     public class ClipperBooleanComponent : GH_Component
     {
+
         /// <summary>
         /// Initializes a new instance of the C# ScriptComponent class.
         /// </summary>
@@ -36,7 +38,9 @@ namespace StudioAvw.Clipper.Components
             pManager.AddCurveParameter("B", "B", "The first polyline", GH_ParamAccess.list);
             pManager[1].Optional = true;
             // ctIntersection, ctUnion, ctDifference, ctXor };
-            pManager.AddIntegerParameter("BooleanType", "BT", "Type: (0: intersection, 1: union, 2: difference, 3: xor)", GH_ParamAccess.item, 0);
+            var btParamIndex = pManager.AddIntegerParameter("BooleanType", "BT", "Type: (0: intersection, 1: union, 2: difference, 3: xor)", GH_ParamAccess.item, 0);
+            var btParam = pManager[btParamIndex] as Param_Integer;
+            ParamHelper.AddEnumOptionsToParam<BooleanClipType>(btParam);
 
             pManager.AddPlaneParameter("Plane", "Pln", "Plane to project the polylines to", GH_ParamAccess.item, default);
             pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
@@ -179,6 +183,18 @@ namespace StudioAvw.Clipper.Components
         /// Gets the unique ID for this component. Do not change this ID after release.
         /// </summary>
         public override Guid ComponentGuid => new Guid("80ab1de3-d9e2-4c5c-8dc8-9edd5ff30fc9");
+
+        /// <summary>
+        /// Just a wrapper for Clipper's ClipType enum.
+        /// Not strictly necessary but avoids exposing the "ct" prefix to users.
+        /// </summary>
+        public enum BooleanClipType
+        {
+            Intersection,
+            Union,
+            Difference,
+            Xor
+        }
     }
 }
 

--- a/ClipperComponents/ClipperComponents.csproj
+++ b/ClipperComponents/ClipperComponents.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="BooleanComponent.cs" />
     <Compile Include="Helpers\DataAccessHelper.cs" />
+    <Compile Include="Helpers\ParamHelper.cs" />
     <Compile Include="Icons.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/ClipperComponents/Helpers/ParamHelper.cs
+++ b/ClipperComponents/Helpers/ParamHelper.cs
@@ -1,0 +1,26 @@
+﻿using Grasshopper.Kernel.Parameters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StudioAvw.Clipper.Components.Helpers
+{
+    public static class ParamHelper
+    {
+        /// <summary>
+        /// Iterates over an Enum type to add the named values to the integer param
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="cfParam"></param>
+        internal static void AddEnumOptionsToParam<T>(Param_Integer cfParam)
+        {
+            foreach (int cfType in Enum.GetValues(typeof(T)))
+            {
+                var name = Enum.GetName(typeof(T), cfType);
+                cfParam.AddNamedValue(name, cfType);
+            }
+        }
+    }
+}

--- a/ClipperComponents/OffsetComponent.cs
+++ b/ClipperComponents/OffsetComponent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
 using Rhino;
 using Rhino.Geometry;
 using StudioAvw.Clipper.Components.Helpers;
@@ -38,9 +39,15 @@ namespace StudioAvw.Clipper.Components
 
             pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
             //public enum ClosedFilletType { Round, Square, Miter }
-            pManager.AddIntegerParameter("ClosedFillet", "CF", "Closed fillet type (0 = Round, 1 = Square, 2 = Miter)", GH_ParamAccess.list, new List<int> { 1 });
-            ////public enum OpenFilletType { Round, Square, Butt }
-            pManager.AddIntegerParameter("OpenFillet", "OF", "Open fillet type (0 = Round, 1 = Square, 2 = Butt)", GH_ParamAccess.list, new List<int> { 1 });
+            var cfParamIndex = pManager.AddIntegerParameter("ClosedFillet", "CF", "Closed fillet type (0 = Round, 1 = Square, 2 = Miter)", GH_ParamAccess.list, new List<int> { 1 });
+            var cfParam = pManager[cfParamIndex] as Param_Integer;
+            ParamHelper.AddEnumOptionsToParam<Polyline3D.ClosedFilletType>(cfParam);
+            
+            //public enum OpenFilletType { Round, Square, Butt }
+            var ofParamIndex = pManager.AddIntegerParameter("OpenFillet", "OF", "Open fillet type (0 = Round, 1 = Square, 2 = Butt)", GH_ParamAccess.list, new List<int> { 1 });
+            var ofParam = pManager[ofParamIndex] as Param_Integer;
+            ParamHelper.AddEnumOptionsToParam<Polyline3D.OpenFilletType>(ofParam);
+
             pManager.AddNumberParameter("Miter", "M", "If closed fillet type of Miter is selected: the maximum extension of a curve is Distance * Miter", GH_ParamAccess.item, 2);
         }
 


### PR DESCRIPTION
This PR uses the `Param_Integer.AddNamedValue` functionality so that the "Enum" types in clipper param inputs (e.g. ClosedFilletType) will show up as text options in a right-click menu. The params remain integer params, so this should not break any backwards compatibility or prevent a user from just feeding an integer value into the param. 

![image](https://user-images.githubusercontent.com/31935763/79749096-94422400-82dc-11ea-9804-c9b7dda7a375.png)