### PR TITLE
Tolerance without active doc

### DIFF
--- a/ClipperComponents/BooleanComponent.cs
+++ b/ClipperComponents/BooleanComponent.cs
@@ -43,7 +43,7 @@ namespace StudioAvw.Clipper.Components
             ParamHelper.AddEnumOptionsToParam<BooleanClipType>(btParam);
 
             pManager.AddPlaneParameter("Plane", "Pln", "Plane to project the polylines to", GH_ParamAccess.item, default);
-            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, DocHelper.GetModelTolerance());
         }
 
         /// <summary>

--- a/ClipperComponents/BooleanComponent.cs
+++ b/ClipperComponents/BooleanComponent.cs
@@ -39,7 +39,7 @@ namespace StudioAvw.Clipper.Components
             pManager.AddIntegerParameter("BooleanType", "BT", "Type: (0: intersection, 1: union, 2: difference, 3: xor)", GH_ParamAccess.item, 0);
 
             pManager.AddPlaneParameter("Plane", "Pln", "Plane to project the polylines to", GH_ParamAccess.item, default);
-            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, DocHelper.GetModelTolerance());
         }
 
         /// <summary>

--- a/ClipperComponents/ClipperComponents.csproj
+++ b/ClipperComponents/ClipperComponents.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="BooleanComponent.cs" />
     <Compile Include="Helpers\DataAccessHelper.cs" />
+    <Compile Include="Helpers\DocHelper.cs" />
     <Compile Include="Icons.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/ClipperComponents/ClipperComponents.csproj
+++ b/ClipperComponents/ClipperComponents.csproj
@@ -49,6 +49,7 @@
     <Compile Include="BooleanComponent.cs" />
     <Compile Include="Helpers\DataAccessHelper.cs" />
     <Compile Include="Helpers\ParamHelper.cs" />
+    <Compile Include="Helpers\DocHelper.cs" />
     <Compile Include="Icons.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/ClipperComponents/Helpers/DocHelper.cs
+++ b/ClipperComponents/Helpers/DocHelper.cs
@@ -1,0 +1,21 @@
+﻿using Rhino;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StudioAvw.Clipper.Components.Helpers
+{
+    public static class DocHelper
+    {
+        /// <summary>
+        /// Safely get model tolerance -- use the active RhinoDoc where present, otherwise return a default.
+        /// </summary>
+        /// <returns></returns>
+        public static double GetModelTolerance()
+        {
+            return RhinoDoc.ActiveDoc?.ModelAbsoluteTolerance ?? 0.01;
+        }
+    }
+}

--- a/ClipperComponents/MinkowskiDifferenceComponent.cs
+++ b/ClipperComponents/MinkowskiDifferenceComponent.cs
@@ -30,7 +30,7 @@ namespace StudioAvw.Clipper.Components
             pManager.AddCurveParameter("A", "A", "The first polyline", GH_ParamAccess.item);
             pManager.AddCurveParameter("B", "B", "The second polyline", GH_ParamAccess.item);
             pManager.AddPlaneParameter("Plane", "Pln", "Plane to project the polylines to", GH_ParamAccess.item, default);
-            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, DocHelper.GetModelTolerance());
         }
 
         /// <summary>

--- a/ClipperComponents/MinkowskiSumComponent.cs
+++ b/ClipperComponents/MinkowskiSumComponent.cs
@@ -31,7 +31,7 @@ namespace StudioAvw.Clipper.Components
             pManager.AddCurveParameter("A", "A", "The first polyline", GH_ParamAccess.item);
             pManager.AddCurveParameter("B", "B", "The second polyline", GH_ParamAccess.item);
             pManager.AddPlaneParameter("Plane", "Pln", "Plane to project the polylines to", GH_ParamAccess.item, default);
-            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, DocHelper.GetModelTolerance());
         }
 
         /// <summary>

--- a/ClipperComponents/OffsetComponent.cs
+++ b/ClipperComponents/OffsetComponent.cs
@@ -37,7 +37,7 @@ namespace StudioAvw.Clipper.Components
             pManager.AddPlaneParameter("Plane", "Pln", "Plane to project the polylines to", GH_ParamAccess.item, default);
 
 
-            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, DocHelper.GetModelTolerance());
             //public enum ClosedFilletType { Round, Square, Miter }
             var cfParamIndex = pManager.AddIntegerParameter("ClosedFillet", "CF", "Closed fillet type (0 = Round, 1 = Square, 2 = Miter)", GH_ParamAccess.list, new List<int> { 1 });
             var cfParam = pManager[cfParamIndex] as Param_Integer;

--- a/ClipperComponents/OffsetComponent.cs
+++ b/ClipperComponents/OffsetComponent.cs
@@ -36,7 +36,7 @@ namespace StudioAvw.Clipper.Components
             pManager.AddPlaneParameter("Plane", "Pln", "Plane to project the polylines to", GH_ParamAccess.item, default);
 
 
-            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, DocHelper.GetModelTolerance());
             //public enum ClosedFilletType { Round, Square, Miter }
             pManager.AddIntegerParameter("ClosedFillet", "CF", "Closed fillet type (0 = Round, 1 = Square, 2 = Miter)", GH_ParamAccess.list, new List<int> { 1 });
             ////public enum OpenFilletType { Round, Square, Butt }

--- a/ClipperComponents/PolygonContainmentComponent.cs
+++ b/ClipperComponents/PolygonContainmentComponent.cs
@@ -31,7 +31,7 @@ namespace StudioAvw.Clipper.Components
             pManager.AddCurveParameter("Polyline", "Pl", "A list of polylines to offset", GH_ParamAccess.item);
             pManager.AddPointParameter("Point", "P", "Offset Distance", GH_ParamAccess.item);
             pManager.AddPlaneParameter("Plane", "Pln", "Plane to project the polylines to", GH_ParamAccess.item, default);
-            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, RhinoDoc.ActiveDoc.ModelAbsoluteTolerance);
+            pManager.AddNumberParameter("Tolerance", "T", "Tolerance: all floating point data beyond this precision will be discarded.", GH_ParamAccess.item, DocHelper.GetModelTolerance());
         }
 
         /// <summary>


### PR DESCRIPTION
I got one more for you :) 

In some run contexts, the RhinoDoc.ActiveDoc is not available (Rhino Compute / Rhino Inside contexts) and this causes clipper to fail. This utility method just supplies a default tolerance if it's not possible to get the rhino doc's tolerance. 

Thanks for merging the others so quickly!  
